### PR TITLE
Fix bug in TA-name and student-numbers

### DIFF
--- a/hak2.sh
+++ b/hak2.sh
@@ -18,6 +18,6 @@ until [ -z "$1" ]; do
 done
 
 i=0
-for stud in `ls -d * | grep "s[0-9]\{7\}\|z[0-9]\{7\}\|e[0-9]\{7\}" | sort -R`; do
+for stud in `ls -d * | grep "[sez][0-9]\{7\}" | sort -R`; do
    mv "$stud" "${dir[$((i++%N))]}"
 done


### PR DESCRIPTION
Allows TA's with name s\* (like mine) and allows students with e[0-9]{7} and z[0-9]{7}

Op dit moment is het zo dat studentassistenten wiens naam met een s begint het script redelijk laten buggen. Ook moeten studenten per se een s-nummer hebben, terwijl er ook soms studenten met z- of e-nummers zijn.

Dit is zo ongeveer de eerste keer dat ik iets in bash doe, dus ik heb geen idee of dit ergens op slaat, maar zover ik deze regel code kan testen werkt het. Heb het gehele script niet getest.
