### PR TITLE
Add f-prefix to user list fetcher

### DIFF
--- a/getsch.sh
+++ b/getsch.sh
@@ -25,7 +25,7 @@ WGET="wget --output-document=- --quiet --no-check-certificate --load-cookies bb.
 
 if [ "$1" == "users" ]; then
     echo 1>&2 Only showing list of studentnumbers and email addresses
-    $WGET "${BBUSERS}&showAll=true" | sed 's/<img[^>]*>//g;/^[[:space:]]*$/d' | sed -n '/profileCardAvatarThumb/{N;s/.*\([suez][0-9]\{6,7\}\).*/\1/p};/@/s/[[:space:]]*\([[:print:]]\+@[[:print:]]\+[.][[:print:]]\+\)<.td>.*/\1/p' | sed -n 'h;n;x;G;s/\n/\t/p'
+    $WGET "${BBUSERS}&showAll=true" | sed 's/<img[^>]*>//g;/^[[:space:]]*$/d' | sed -n '/profileCardAvatarThumb/{N;s/.*\([suezf][0-9]\{6,7\}\).*/\1/p};/@/s/[[:space:]]*\([[:print:]]\+@[[:print:]]\+[.][[:print:]]\+\)<.td>.*/\1/p' | sed -n 'h;n;x;G;s/\n/\t/p'
     exit
 fi
 


### PR DESCRIPTION
FSW stopt een of andere dude met een f-nummer in elke Blackboard cursus. Doet verder niks en kan ook niks inleveren, maar maakt wel de userlist kapot. Dit fixed dat!
