### PR TITLE
Changed the unpack commands to keep their full path

### DIFF
--- a/antifmt.sh
+++ b/antifmt.sh
@@ -15,9 +15,9 @@ CATDOC="$HOME/catdoc/bin/catdoc"
 STUDDIRS="[sez][0-9]*"
 
 declare -A unpack
-de.zip() { unzip -a -n -j -d "${1%/*}" "$1"; }
-de.rar() { unrar e -o- "$1" "${1%/*}"; }
-de.7z()  { 7zr e -y -o"${1%/*}" "$1"; }
+de.zip() { unzip -a -n -d "${1%/*}" "$1"; }
+de.rar() { unrar x -o- "$1" "${1%/*}"; }
+de.7z()  { 7zr x -y -o"${1%/*}" "$1"; }
 unpack[application/zip]=de.zip
 unpack[application/x-7z-compressed]=de.7z
 unpack[application/x-rar]=de.rar


### PR DESCRIPTION
Een oplossing voor Issue #5 (https://github.com/squell/bb-scripts/issues/5). Commando's zijn aangepast om de mappenstructuur in tact te houden.
De vraag blijft dus echter of er niet een bewuste keuze is gemaakt om dit niet te doen, en zo ja, waarom dan wel?
