### PR TITLE
mksdir improvements

### DIFF
--- a/mksdir.sh
+++ b/mksdir.sh
@@ -3,40 +3,35 @@
 # create a emulated s123456 directory + fake response file
 # use if someone who submitted manually :(
 
+# Usage: $ ./mksdir.sh Full Name
+
 set -e
 
-NAME="$1"
+FULLNAME="$@"
+NAME="${FULLNAME##* }"
+ASSIGNMENT="Week x"
 
 select name in $(grep -i "$NAME" "${0%/*}/userlist" | tr '\t' '|'); do
 	DIR=`echo "$name" | cut -f1 -d'|'`
 	break
 done
 
-if [ -e "$DIR" ]; then
-	echo "$DIR" already exists!
-	exit 1
-fi
-
 if [ -z "$DIR" ]; then
 	echo User not found.
 	exit 1
 fi
 
-if [ -z "$DIR" ]; then
-	echo Aborted.
+if [ -e "$DIR" ]; then
+	echo "$DIR" already exists!
 	exit 1
 fi
 
 echo "creating $DIR"
 mkdir -p "$DIR"
 cat >> "$DIR/$DIR.txt" <<EOF
-Name: $NAME ($DIR)
-Assignment:Week x
-Date Submitted:$(date)
-Current Grade:Not Yet Graded
+Name: $FULLNAME ($DIR)
+Assignment: $ASSIGNMENT
+Date Submitted: $(date)
+Current Grade: Not Yet Graded
 
-Submission Field:
-gesubmit per email
-Files:
-$*
 EOF

--- a/mksdir.sh
+++ b/mksdir.sh
@@ -3,17 +3,29 @@
 # create a emulated s123456 directory + fake response file
 # use if someone who submitted manually :(
 
-# Usage: $ ./mksdir.sh Full Name
+# Usage: ./mksdir.sh "Student One" "Student Two"
+# works for any number of students.
 
 set -e
 
-FULLNAME="$@"
-NAME="${FULLNAME##* }"
-ASSIGNMENT="Week x"
+if [ -e "grades.csv" ]; then
+	ASSIGNMENT=$(cat grades.csv)
+	ASSIGNMENT=${ASSIGNMENT#*\"}
+	ASSIGNMENT=${ASSIGNMENT%|*}
+else
+	echo Please select an assignment first.
+	exit 1
+fi
 
-select name in $(grep -i "$NAME" "${0%/*}/userlist" | tr '\t' '|'); do
-	DIR=`echo "$name" | cut -f1 -d'|'`
-	break
+NAMELINES=
+
+for NAME in "$@"; do
+	TMP="${NAME##* }"
+	select name in $(grep -i "$TMP" "${0%/*}/userlist" | tr '\t' '|'); do
+		DIR="$(echo "$name" | cut -f1 -d'|')"
+		break
+	done
+	NAMELINES+="Name: $NAME ($DIR)"$'\n'
 done
 
 if [ -z "$DIR" ]; then
@@ -29,8 +41,7 @@ fi
 echo "creating $DIR"
 mkdir -p "$DIR"
 cat >> "$DIR/$DIR.txt" <<EOF
-Name: $FULLNAME ($DIR)
-Assignment: $ASSIGNMENT
+${NAMELINES}Assignment: $ASSIGNMENT
 Date Submitted: $(date)
 Current Grade: Not Yet Graded
 


### PR DESCRIPTION
I improved mksdir a little. It now accepts multiple names. It uses full names as input and uses the last word in the name to search the userlist. This works as all student email addresses must end in their last name. If this fails you can still select students with their student number, you just need to change the name manually afterwards. This used to be necessary every time. The result is normalized to look more like the files generated by blackboard.