### PR TITLE
Doesn't fix #19 but makes it less likely to occur

### DIFF
--- a/antifmt.sh
+++ b/antifmt.sh
@@ -47,7 +47,7 @@ done
 # unpdfize stuff
 echo Extracting text from PDF files \(`ls ${STUDDIRS}/*.pdf 2> /dev/null | wc -l`\)
 for file in ${STUDDIRS}/*.pdf; do
-	[ "$file" != "${STUDDIRS}/*.pdf" ] && pdftotext -layout "$file"
+	[ "$file" != "${STUDDIRS}/*.pdf" ] && pdftotext -layout "$file" "$file.txt"
 done
 
 # complain about word


### PR DESCRIPTION
antifmt.sh maakt van xyz.pdf nu een xyz.pdf.txt om clashes tegen te gaan. Idealiter zou de gebruiker interactief worden gevraagd wat er moet gebeuren als een bestand al bestaat, maar dat is meer werk.