### PR TITLE
Fix mailto.sh for lilo5

### DIFF
--- a/mailto.sh
+++ b/mailto.sh
@@ -62,7 +62,7 @@ for file in "$@"; do
 		echo Could not find any email address for students: $TOID! >&2
 		touch "${file}.could_not_sent"
 	else
-		sed -n '/^Date/p;/^Current Grade:/p;/^Feedback:/,$p' "$file" | tr -d '\r' | mail -a "$MIME" -n -s "$SUBJECT" ${FROM:+-a "From: $FROM"} ${BCC:+-b "$BCC"} $TO && echo "$TO" > "${file}.sent"
+		sed -n '/^Date/p;/^Current Grade:/p;/^Feedback:/,$p' "$file" | tr -d '\r' | mail -a "$MIME" -n -s "$SUBJECT" ${FROM:+-a "From: $FROM"} ${BCC:+-a "Bcc: $BCC"} $TO && echo "$TO" > "${file}.sent"
 		#sed -n '/^Date/p;/^Current Grade:/p;/^Feedback:/,$p' "$file" | tr -d '\r' | "${0%/*}"/xmail.sh -a "$MIME" -s "$SUBJECT" ${FROM:+-f "$FROM"} ${BCC:+-b "$BCC"} $TO && echo "$TO" > "${file}.sent"
 	fi
 done


### PR DESCRIPTION
On lilo5 (Ubuntu 16.04), the `mail` command has been updated and the `-b` option does not work for a reason unclear to me; the manpage still documents it. Adding `-a 'Bcc: <email>'` works though.