### PR TITLE
Make sure bsd-mailx is used

### DIFF
--- a/mailto.sh
+++ b/mailto.sh
@@ -62,7 +62,7 @@ for file in "$@"; do
 		echo Could not find any email address for students: $TOID! >&2
 		touch "${file}.could_not_sent"
 	else
-		sed -n '/^Date/p;/^Current Grade:/p;/^Feedback:/,$p' "$file" | tr -d '\r' | mail -a "$MIME" -n -s "$SUBJECT" ${FROM:+-a "From: $FROM"} ${BCC:+-a "Bcc: $BCC"} $TO && echo "$TO" > "${file}.sent"
+		sed -n '/^Date/p;/^Current Grade:/p;/^Feedback:/,$p' "$file" | tr -d '\r' | bsd-mailx -a "$MIME" -n -s "$SUBJECT" ${FROM:+-a "From: $FROM"} ${BCC:+-a "Bcc: $BCC"} $TO && echo "$TO" > "${file}.sent"
 		#sed -n '/^Date/p;/^Current Grade:/p;/^Feedback:/,$p' "$file" | tr -d '\r' | "${0%/*}"/xmail.sh -a "$MIME" -s "$SUBJECT" ${FROM:+-f "$FROM"} ${BCC:+-b "$BCC"} $TO && echo "$TO" > "${file}.sent"
 	fi
 done


### PR DESCRIPTION
So, C&CZ now decided to use `s-nail` instead `bsd-mailx` for `mail`, and the command line options are not compatible. Just using `mailx` is not sufficient, this now also maps to `s-nail` on lilo5. Using `bsd-mailx` works on both lilo4 and lilo5...