### PR TITLE
groepjes.sh: separate items by null instead of space

### DIFF
--- a/groepjes.sh
+++ b/groepjes.sh
@@ -39,7 +39,7 @@ for dir in "$@"; do
 	#TOID=`sed -n '/Name:/s/.*\([sez][0-9]\+\).*/\1/p' "$file"`
 	#TOID=`grep -oi '\<[sez]\?[0-9]\{6,7\}\>' "$file" | tr SEZ sez | sort -u`
 	#TOID=`grep -oihI '\<[usefz]\?[0-9]\{6,7\}\>' "${file%%/*}"/* | sed 's/\<[0-9]/s&/' | tr USEFZ usefz`
-	TOID=`find "${file%%/*}" -type f -not -name "*.WARNING" | xargs grep -oihI '\<[usefz]\?[0-9]\{6,7\}\>' | sed 's/\<[0-9]/s&/' | tr USEFZ usefz`
+	TOID=`find "${file%%/*}" -type f -not -name "*.WARNING" -print0 | xargs --null grep -oihI '\<[usefz]\?[0-9]\{6,7\}\>' | sed 's/\<[0-9]/s&/' | tr USEFZ usefz`
 	for id in $TOID; do
 		grep "$id" "$USERLIST" | cut -f1,2 | sed 's/@[[:print:]]*\>//g'
 	done | sort -u | tr '\t\n' ' ' | sed 's/[^0-9] \</&<with> /g'


### PR DESCRIPTION
The script fails if a student delivers a submission with spaces in paths, like "Exercise 1". `find` finds this path and passes it to `xargs`, which thinks it's actually two items. This PR tells `find` and `xargs` to use null-seperated lists, instead of space-separated lists, fixing the bug.