### PR TITLE
Use libreoffice instead of catdoc and hacks

### DIFF
--- a/antifmt.sh
+++ b/antifmt.sh
@@ -7,16 +7,6 @@
 # - convert docx/odt to text using hacks
 # - correct line-endings {CR/LF, CR} -> LF
 # - print a list of people who think Word is an IDE
-
-# NECESSARY: catdoc built&installed, somewhere:
-CATDOC="$HOME/catdoc/bin/catdoc"
-
-if [ -z "$*" ]; then
-	echo "Usage: antifmt.sh DIR1 DIR2 ..." >& 2
-	exit 1
-fi
-
-
 shopt -s nullglob
 
 typeset -A unpack
@@ -73,21 +63,11 @@ for studdir in "$@"; do
 	done
 
 	# complain about word
-	if [ -x "$CATDOC" ]; then
-	for type in doc rtf; do
+	for type in docx odt doc rtf; do
 	    for file in "$studdir"/*.$doc; do
-		let "stat[type]++"
-		$CATDOC "${file}" > "${file}.$doc".txt
+			let "stat[type]++"
+			soffice --headless --cat "$file" > "$file.txt"
 	    done
-	done
-	fi
-	for file in "$studdir"/*.docx; do
-		let "stat[docx]++"
-		unzip -p "$file" word/document.xml | sed 's|<w:br/>|\n&|g;s|</w:p>|\n&|g;s|<[^>]*>||g' > "${file}".txt
-	done
-	for file in "$studdir"/*.odt; do
-		let "stat[odt]++"
-		unzip -p "$file" content.xml | sed 's|<text:tab/>|\t|g;s|<text:p|\n&|g;s|<[^>]*>||g' > "${file}".txt
 	done
 
 	# kill all binaries

--- a/antifmt.sh
+++ b/antifmt.sh
@@ -1,13 +1,17 @@
 #! /bin/bash
 
 # repair all the creative stuff students submit
-# - unzip all zips en rars (w/o directory structure)
+# - unzip all compressed files/dirs (w/o directory structure)
 # - convert pdfs to text using pdftotext
-# - convert doc/rtf to text using catdoc
-# - convert docx/odt to text using hacks
+# - convert doc/rtf/docx/odt to text using libreoffice
 # - correct line-endings {CR/LF, CR} -> LF
 # - print a list of people who think Word is an IDE
 shopt -s nullglob
+
+if [ -z "$*" ]; then
+	echo "Usage: antifmt.sh DIR1 DIR2 ..." >& 2
+	exit 1
+fi
 
 typeset -A unpack
 de.zip() { unzip -a -n -j -d "${1%/*}" "$1"; }

--- a/antifmt.sh
+++ b/antifmt.sh
@@ -91,7 +91,7 @@ for studdir in "$@"; do
 	done
 
 	# kill all binaries
-	rm -f "$studdir"/{*.o,*.obj,*.exe,*.prj,*.abc}
+	rm -f "$studdir"/{*.o,*.obj,*.exe,*.prj,*.prp,*.abc}
 	rm -f "$studdir"/{*.class,*.jar}
 	rm -f "$studdir"/{*.zip,*.rar,*.7z,*.tar}
 


### PR DESCRIPTION
`libreoffice` is installed on lilo and can do headless batch conversion to text.
`catdoc` is not on lilo and must be installed by the TA theirselves.
The hacks are hacks, but just hacks.

Apparently the removal of `prp` files (clean windows IDE preferences) commit is included too.