### PR TITLE
Use 7za instead of unzip because of dos codepages

### DIFF
--- a/bsunzip.sh
+++ b/bsunzip.sh
@@ -47,7 +47,7 @@ unmojibake() {
 #(export LC_CTYPE=POSIX; unzip -q -o -d "$DEST" "$1")
 # not all systems have an unzip that does not mangle the filenames even with
 # the correct locale, therefore we fall back to 7z
-7za x -bd -o"$DEST" "$1"
+7za x -y -bd -o"$DEST" "$1"
 
 ADDED="#comments.txt"
 

--- a/bsunzip.sh
+++ b/bsunzip.sh
@@ -2,7 +2,7 @@
 
 # unzip a brightspace-provided file, and split the index.html it contains over the subdirectories
 
-for cmd in unzip iconv; do
+for cmd in unzip iconv 7za; do
 	if ! command -v $cmd >/dev/null 2>&1; then
 		echo "Who am I? Why am I here? Am I on lilo? $cmd is missing!" >& 2
 		exit 1
@@ -43,7 +43,10 @@ unmojibake() {
 
 # however, by running unzip in the POSIX locale, we can circumvent
 # this from even becoming a problem, and so the above macro is not called anymore
-(export LC_CTYPE=POSIX; unzip -q -o -d "$DEST" "$1")
+#(export LC_CTYPE=POSIX; unzip -q -o -d "$DEST" "$1")
+# not all systems have an unzip that does not mangle the filenames even with
+# the correct locale, therefore we fall back to 7z
+7za x -bd -o"$DEST" "$1"
 
 ADDED="#comments.txt"
 


### PR DESCRIPTION
`7za` does not mangle the filepaths. It is already a somewhat of a dependency anyway.

unzip on my machine: `6.0-21`
unzip on lilo: `6.0-20ubuntu1`

So my guess is that ubuntu has patched unzip to have this behaviour.
Even with the modified locale unzip still mojibakes