### PR TITLE
bsunzip: only sanitize directory name if different

### DIFF
--- a/bsunzip.sh
+++ b/bsunzip.sh
@@ -78,7 +78,10 @@ for submission in "$DEST"/*/; do
 
 	# remove the ':' character from the directory name
 	sanitized_name="$(echo -n "$submission" | tr ':' '_')"
-	mv "$submission" "$sanitized_name"
+	if [ "$submission" != "$sanitized_name" ]
+	then
+		mv "$submission" "$sanitized_name"
+	fi
 	submission="$sanitized_name"
 
 	if echo "$comment" | grep -F -e '<script'  -e '<style'; then

--- a/bsunzip.sh
+++ b/bsunzip.sh
@@ -78,8 +78,7 @@ for submission in "$DEST"/*/; do
 
 	# remove the ':' character from the directory name
 	sanitized_name="$(echo -n "$submission" | tr ':' '_')"
-	if [ "$submission" != "$sanitized_name" ]
-	then
+	if [ "$submission" != "$sanitized_name" ]; then
 		mv "$submission" "$sanitized_name"
 	fi
 	submission="$sanitized_name"


### PR DESCRIPTION
When unpacking several downloaded .zip files, earlier file names are
already sanitized, leading to warning messages from mv