### PR TITLE
add reformatting to mailto.sh

### DIFF
--- a/mailto.sh
+++ b/mailto.sh
@@ -45,7 +45,9 @@ for file in "$@"; do
 		echo Could not find any email address to send "$file" to >&2
 		touch "${file}.could_not_sent"
 	else
-		cat "$file" | tr -d '\r' | bsd-mailx -a "$MIME" -n -s "$SUBJECT" ${FROM:+-a "From: $FROM"} ${BCC:+-a "Bcc: $BCC"} ${BCC:+-b "$BCC"} $TO && echo "$TO" > "${file}.sent"
+		wrap="TEXT"
+		cat "$file" | tr -d '\r' | sed "s/^[^>]/${wrap}&/" | fmt -u -c -w80 -p"$wrap" | sed "s/^${wrap}//" |
+		  bsd-mailx -a "$MIME" -n -s "$SUBJECT" ${FROM:+-a "From: $FROM"} ${BCC:+-a "Bcc: $BCC"} ${BCC:+-b "$BCC"} $TO && echo "$TO" > "${file}.sent"
 	fi
 done
 


### PR DESCRIPTION
Feedback.txt files can come out a bit messy. I've experimented with this change:

* use `fmt` to reflow the paragraphs

* with this change, if you want to put preformatted text in feedback, that should not be re-formatted, quote it by beginning the line with ">".

Is this something people can live with?

Another option of course would be to use Markdown to generate a HTLM version of the given feedback, but that is more work.