### PR TITLE
Add option for inequal distributions of workload

### DIFF
--- a/hak3.sh
+++ b/hak3.sh
@@ -1,28 +1,52 @@
 #! /bin/bash
 
 # partition ALL SUBDIRECTORIES in equal parts into the folders given as arguments
-
 shopt -s nullglob
+
+numFolders=$(find * -maxdepth 0 -type d | wc -l)
 
 if [ -z "$1" ]; then
     echo "usage: hak3.sh <dir1> <dir2> ... <dirN>" >&2
     exit 1
 fi
 
-N=$#
+N=$(($#/2))
 
 i=$RANDOM
+typeset -A distribution
 until [ -z "$1" ]; do
     # temporarily hide the folders we are sorting into
     test -d "$1" && mv "$1" ".$1"
     mkdir -p ".$1"
-    dir[$((i++%N))]="$1"
+    dir[$((i%N))]="$1"
+    echo "dir: $1"
+    shift
+    echo "val: $1"
+    distribution[$((i++%N))]=$(echo "$1*$numFolders" | bc | mawk '{print int($1+0.5)}')
     shift
 done
 
+part(){
+    j=$1
+
+    if [ "${distribution[$(((i+j)%N))]}" -gt "0" ]; then
+        mv "$stud" ."${dir[$(((i+j)%N))]}"
+        echo $((j+1))
+        return
+    fi
+
+    if [ "$j" -ge "$N" ]; then
+        echo "FUCK"
+    fi
+
+    echo $(part $((j+1)))
+}
+
 i=0
 shuf -ze */ | while read -d $'\0' stud; do
-    mv "$stud" ."${dir[$((i++%N))]}"
+    j=$(part 0)
+    i=$((i+j))
+    distribution[$(((i-1)%N))]=$((${distribution[$(((i-1)%N))]}-1))
 done
 
 for dir in "${dir[@]}"; do


### PR DESCRIPTION
Hi, I'm currently working as a TA for functional programming for AI.
We had an issue that one of the TAs should have a higher workload than the others.
Our quick fix was of course to add the TAs multiple times which is very annoying because everyone would get multiple emails etc.  

Anyway long story short, I made some changes to introduce an (optional) distribution array which allows the script to partition the work. It works perfectly in my tests but I haven't done much bash scripting before so it might have some bugs that I missed.

Hope it's something you guys approve of